### PR TITLE
Adding some type array functionality.

### DIFF
--- a/jsonq.go
+++ b/jsonq.go
@@ -9,19 +9,22 @@ type JsonQuery struct {
 	blob map[string]interface{}
 }
 
-// Create a new JsonQuery obj from a json-decoded interface{}
-func NewQuery(data interface{}) *JsonQuery {
-	j := new(JsonQuery)
-	j.blob = data.(map[string]interface{})
-	return j
+/*
+The following methods are identical to the routines that were originally embedded in the realted query methods.
+They are seperated out here to keep the code as dry as possible.
+*/
+
+//stringFromInterface converts an interface{} to a string and returns an error if types don't match.
+func stringFromInterface(val interface{}) (string, error) {
+	switch val.(type) {
+	case string:
+		return val.(string), nil
+	}
+	return "", fmt.Errorf("Expected string value for String, got \"%v\"\n", val)
 }
 
-// Extract a Bool from some json
-func (j *JsonQuery) Bool(s ...string) (bool, error) {
-	val, err := rquery(j.blob, s...)
-	if err != nil {
-		return false, err
-	}
+//boolFromInterface converts an interface{} to a bool and returns an error if types don't match.
+func boolFromInterface(val interface{}) (bool, error) {
 	switch val.(type) {
 	case bool:
 		return val.(bool), nil
@@ -29,12 +32,8 @@ func (j *JsonQuery) Bool(s ...string) (bool, error) {
 	return false, fmt.Errorf("Expected boolean value for Bool, got \"%v\"\n", val)
 }
 
-// Extract a float from some json
-func (j *JsonQuery) Float(s ...string) (float64, error) {
-	val, err := rquery(j.blob, s...)
-	if err != nil {
-		return 0.0, err
-	}
+//floatFromInterface converts an interface{} to a float64 and returns an error if types don't match.
+func floatFromInterface(val interface{}) (float64, error) {
 	switch val.(type) {
 	case float64:
 		return val.(float64), nil
@@ -49,12 +48,8 @@ func (j *JsonQuery) Float(s ...string) (float64, error) {
 	return 0.0, fmt.Errorf("Expected numeric value for Float, got \"%v\"\n", val)
 }
 
-// Extract an int from some json
-func (j *JsonQuery) Int(s ...string) (int, error) {
-	val, err := rquery(j.blob, s...)
-	if err != nil {
-		return 0, err
-	}
+//intFromInterface converts an interface{} to an int and returns an error if types don't match.
+func intFromInterface(val interface{}) (int, error) {
 	switch val.(type) {
 	case float64:
 		return int(val.(float64)), nil
@@ -69,17 +64,65 @@ func (j *JsonQuery) Int(s ...string) (int, error) {
 	return 0, fmt.Errorf("Expected numeric value for Int, got \"%v\"\n", val)
 }
 
+//objectFromInterface converts an interface{} to a map[string]interface{} and returns an error if types don't match.
+func objectFromInterface(val interface{}) (map[string]interface{}, error) {
+	switch val.(type) {
+	case map[string]interface{}:
+		return val.(map[string]interface{}), nil
+	}
+	return map[string]interface{}{}, fmt.Errorf("Expected json object for Object, get \"%v\"\n", val)
+}
+
+//arrayFromInterface converts an interface{} to an []interface{} and returns an error if types don't match.
+func arrayFromInterface(val interface{}) ([]interface{}, error) {
+	switch val.(type) {
+	case []interface{}:
+		return val.([]interface{}), nil
+	}
+	return []interface{}{}, fmt.Errorf("Expected json array for Array, get \"%v\"\n", val)
+}
+
+// Create a new JsonQuery obj from a json-decoded interface{}
+func NewQuery(data interface{}) *JsonQuery {
+	j := new(JsonQuery)
+	j.blob = data.(map[string]interface{})
+	return j
+}
+
+// Extract a Bool from some json
+func (j *JsonQuery) Bool(s ...string) (bool, error) {
+	val, err := rquery(j.blob, s...)
+	if err != nil {
+		return false, err
+	}
+	return boolFromInterface(val)
+}
+
+// Extract a float from some json
+func (j *JsonQuery) Float(s ...string) (float64, error) {
+	val, err := rquery(j.blob, s...)
+	if err != nil {
+		return 0.0, err
+	}
+	return floatFromInterface(val)
+}
+
+// Extract an int from some json
+func (j *JsonQuery) Int(s ...string) (int, error) {
+	val, err := rquery(j.blob, s...)
+	if err != nil {
+		return 0, err
+	}
+	return intFromInterface(val)
+}
+
 // Extract a string from some json
 func (j *JsonQuery) String(s ...string) (string, error) {
 	val, err := rquery(j.blob, s...)
 	if err != nil {
 		return "", err
 	}
-	switch val.(type) {
-	case string:
-		return val.(string), nil
-	}
-	return "", fmt.Errorf("Expected string value for String, got \"%v\"\n", val)
+	return stringFromInterface(val)
 }
 
 // Extract an object from some json
@@ -88,11 +131,7 @@ func (j *JsonQuery) Object(s ...string) (map[string]interface{}, error) {
 	if err != nil {
 		return map[string]interface{}{}, err
 	}
-	switch val.(type) {
-	case map[string]interface{}:
-		return val.(map[string]interface{}), nil
-	}
-	return map[string]interface{}{}, fmt.Errorf("Expected json object for Object, get \"%v\"\n", val)
+	return objectFromInterface(val)
 }
 
 // Extract an array from some json
@@ -101,11 +140,112 @@ func (j *JsonQuery) Array(s ...string) ([]interface{}, error) {
 	if err != nil {
 		return []interface{}{}, err
 	}
-	switch val.(type) {
-	case []interface{}:
-		return val.([]interface{}), nil
+	return arrayFromInterface(val)
+}
+
+/*
+Extract typed slices.
+*/
+
+//ArrayOfStrings extracts an array of strings from some json
+func (j *JsonQuery) ArrayOfStrings(s ...string) ([]string, error) {
+	array, err := j.Array(s...)
+	if err != nil {
+		return []string{}, err
 	}
-	return []interface{}{}, fmt.Errorf("Expected json array for Array, get \"%v\"\n", val)
+	toReturn := make([]string, len(array))
+	for index, val := range array {
+		toReturn[index], err = stringFromInterface(val)
+		if err != nil {
+			return toReturn, err
+		}
+	}
+	return toReturn, nil
+}
+
+//ArrayOfInts extracts an array of ints from some json
+func (j *JsonQuery) ArrayOfInts(s ...string) ([]int, error) {
+	array, err := j.Array(s...)
+	if err != nil {
+		return []int{}, err
+	}
+	toReturn := make([]int, len(array))
+	for index, val := range array {
+		toReturn[index], err = intFromInterface(val)
+		if err != nil {
+			return toReturn, err
+		}
+	}
+	return toReturn, nil
+}
+
+//ArrayOfFloats extracts an array of float64s from some json
+func (j *JsonQuery) ArrayOfFloats(s ...string) ([]float64, error) {
+	array, err := j.Array(s...)
+	if err != nil {
+		return []float64{}, err
+	}
+	toReturn := make([]float64, len(array))
+	for index, val := range array {
+		toReturn[index], err = floatFromInterface(val)
+		if err != nil {
+			return toReturn, err
+		}
+	}
+	return toReturn, nil
+}
+
+//ArrayOfBools extracts an array of bools from some json
+func (j *JsonQuery) ArrayOfBools(s ...string) ([]bool, error) {
+	array, err := j.Array(s...)
+	if err != nil {
+		return []bool{}, err
+	}
+	toReturn := make([]bool, len(array))
+	for index, val := range array {
+		toReturn[index], err = boolFromInterface(val)
+		if err != nil {
+			return toReturn, err
+		}
+	}
+	return toReturn, nil
+}
+
+//ArrayOfObjects extracts an array of map[string]interface{} (objects) from some json
+func (j *JsonQuery) ArrayOfObjects(s ...string) ([]map[string]interface{}, error) {
+	array, err := j.Array(s...)
+	if err != nil {
+		return []map[string]interface{}{}, err
+	}
+	toReturn := make([]map[string]interface{}, len(array))
+	for index, val := range array {
+		toReturn[index], err = objectFromInterface(val)
+		if err != nil {
+			return toReturn, err
+		}
+	}
+	return toReturn, nil
+}
+
+//ArrayOfArrays extracts an array of []interface{} (arrays) from some json
+func (j *JsonQuery) ArrayOfArrays(s ...string) ([][]interface{}, error) {
+	array, err := j.Array(s...)
+	if err != nil {
+		return [][]interface{}{}, err
+	}
+	toReturn := make([][]interface{}, len(array))
+	for index, val := range array {
+		toReturn[index], err = arrayFromInterface(val)
+		if err != nil {
+			return toReturn, err
+		}
+	}
+	return toReturn, nil
+}
+
+//Matrix2D is an alias for ArrayOfArrays
+func (j *JsonQuery) Matrix2D(s ...string) ([][]interface{}, error) {
+	return j.ArrayOfArrays(s...)
 }
 
 // Recursively query a decoded json blob

--- a/jsonq_test.go
+++ b/jsonq_test.go
@@ -28,6 +28,16 @@ const TestData = `{
 			"array": ["hello", "world"]
 		}
 	},
+	"collections": {
+		"bools": [false, true, false],
+		"strings": ["hello", "strings"],
+		"numbers": [1,2,3,4],
+		"arrays": [[1.0,2.0],[2.0,3.0],[4.0,3.0]],
+		"objects": [
+			{"obj1": 1},
+			{"obj2": 2}
+		]
+	},
 	"bool": true
 }`
 
@@ -120,4 +130,51 @@ func TestQuery(t *testing.T) {
 	if aobj[0].(float64) != 1 {
 		t.Errorf("Expecting 1, got %v\n", aobj[0])
 	}
+
+	/*
+		Test Extraction of typed slices
+	*/
+
+	//test array of strings
+	astrings, err := q.ArrayOfStrings("collections", "strings")
+	tErr(t, err)
+	if astrings[0] != "hello" {
+		t.Errorf("Expecting hello, got %v\n", astrings[0])
+	}
+
+	//test array of ints
+	aints, err := q.ArrayOfInts("collections", "numbers")
+	tErr(t, err)
+	if aints[0] != 1 {
+		t.Errorf("Expecting 1, got %v\n", aints[0])
+	}
+
+	//test array of floats
+	afloats, err := q.ArrayOfFloats("collections", "numbers")
+	tErr(t, err)
+	if afloats[0] != 1.0 {
+		t.Errorf("Expecting 1.0, got %v\n", afloats[0])
+	}
+
+	//test array of bools
+	abools, err := q.ArrayOfBools("collections", "bools")
+	tErr(t, err)
+	if abools[0] {
+		t.Errorf("Expecting true, got %v\n", abools[0])
+	}
+
+	//test array of arrays
+	aa, err := q.ArrayOfArrays("collections", "arrays")
+	tErr(t, err)
+	if aa[0][0].(float64) != 1 {
+		t.Errorf("Expecting 1, got %v\n", aa[0][0])
+	}
+
+	//test array of objs
+	aobjs, err := q.ArrayOfObjects("collections", "objects")
+	tErr(t, err)
+	if aobjs[0]["obj1"].(float64) != 1 {
+		t.Errorf("Expecting 1, got %v\n", aobjs[0]["obj1"])
+	}
+
 }


### PR DESCRIPTION
Hey I use this library a lot in my personal projects. One of the things that I find my self doing over and over again is retrieving an array and then walking through it in order to change the type from say []interface{} to []string. In order to capitalize on some of the nice safeties you have built in for the conversions I find myself making ugly routines that essentially use jsonq to find the array, get its length and then iterate over the length using jsonq to return each of the  indexes. There are obviously several ways of doing this however I think that it would be nice to have some of these routines built in. I realize that JSON arrays don't have to contain objects of only one type but when working with exchanges between multiple well typed go apis it might make more sense to assume arrays will contain like types.

For example using the available api we might do something like this:

``` go
//function that we want to call after unpacking the json
func DoSomething(strings []strings) {}

func main() {
        //json however you get it
    const json = `{
        "collections": {
            "strings": ["hello", "strings"]
        }
    }`

    data := map[string]interface{}{}
    dec := json.NewDecoder(strings.NewReader(json))
    dec.Decode(&data)
    q := NewQuery(data)
    //get the array
    a, err := q.Array("collections", "strings")
    if err != nil {
        //handle error
    }
        //begin conversion
    stringArray := make([]string, len(a))
    for i := range a {
                //conversion of choice here but you lose what this lib gives you with floats for example
        s, err := q.String("collections", "strings", i)
        if err != nil {
            //handle error
        }
        stringArray[i] = s
    }
        //do what we actually wanted to do
    DoSomething(stringArray)
}
```

I have extended the API with the following functions

``` go
//ArrayOfStrings extracts an array of strings from some json
func (j *JsonQuery) ArrayOfStrings(s ...string) ([]string, error)
//ArrayOfInts extracts an array of ints from some json
func (j *JsonQuery) ArrayOfInts(s ...string) ([]int, error)
//ArrayOfFloats extracts an array of float64s from some json
func (j *JsonQuery) ArrayOfFloats(s ...string) ([]float64, error)
//ArrayOfBools extracts an array of bools from some json
func (j *JsonQuery) ArrayOfBools(s ...string) ([]bool, error)
//ArrayOfObjects extracts an array of map[string]interface{} (objects) from some json
func (j *JsonQuery) ArrayOfObjects(s ...string) ([]map[string]interface{}, error)
//ArrayOfArrays extracts an array of []interface{} (arrays) from some json
func (j *JsonQuery) ArrayOfArrays(s ...string) ([][]interface{}, error) 
//Matrix2D is an alias for ArrayOfArrays
func (j *JsonQuery) Matrix2D(s ...string) ([][]interface{}, error)
```

This would allow us to rewrite the above example like this:

``` go
func DoSomething(strings []strings) {}

func main() {
    const json = `{
        "collections": {
            "strings": ["hello", "strings"],
        }
    }`

    data := map[string]interface{}{}
    dec := json.NewDecoder(strings.NewReader(json))
    dec.Decode(&data)
    q := NewQuery(data)
    stringArray, err := q.ArrayOfStrings("collections", "strings")
    if err != nil {
        //handle error
    }
    DoSomething(stringArray)
}
```

Which is a little more manageable and also drops some of the recursive calls while preserving the existing type conversion routines.

Let me know what you think about these modifications. I followed your lead with the testing suite. If you want to see more rigorous testing or want to split up the main jsonq file let me know. Anyway thanks for the great library.
