### PR TITLE
Added path functions and single value return functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,29 @@ jq.String("subobj", "subsubobj", "array", "0")
 obj, err := jq.Object("subobj")
 ```
 
+Also you can query using a *path* specification as show in the examples below:
+
+```go
+// data["subobj"]["subarray"][1] -> 2
+jq.Int("subobj.subarray[1]")
+
+// data["subobj"]["subarray"]["array"][0] -> "hello"
+jq.String("subobj.subsubobj.array[0]")
+```
+
+Finally, As functions have been included so that if you are *sure* the call will succeed you can inline the
+values. If these calls encounter an error they will panic:
+
+```go
+// data["subobj"]["subarray"][1] -> 2
+fmt.Printf("%d\n", jq.AsInt("subobj", "subarray", "1"))
+fmt.Printf("%d\n", jq.AsInt("subobj.subarray[1]"))
+
+// data["subobj"]["subarray"]["array"][0] -> "hello"
+fmt.Printf("%s\n", jq.AsString("subobj", "subsubobj", "array", "0"))
+fmt.Printf("%s\n", jq.AsString("subobj.subsubobj.array[0]"))
+```
+
 Missing keys, out of bounds indexes, and type failures will return errors.
 For simplicity, integer keys (ie, {"0": "zero"}) are inaccessible
 by `jsonq` as integer strings are assumed to be array indexes.
@@ -80,4 +103,3 @@ The `Int` and `Float` methods will attempt to parse numbers from string
 values to ease the use of many real world feeds which deliver numbers as strings.
 
 Suggestions/comments please tweet [@jmoiron](http://twitter.com/jmoiron)
-

--- a/doc.go
+++ b/doc.go
@@ -52,6 +52,29 @@ From here, you can query along different keys and indexes:
 	// data["subobj"] -> map[string]interface{}{"subobj": ...}
 	obj, err := jq.Object("subobj")
 
+Also you can query using a *path* specification as show in the examples below:
+
+	```go
+	// data["subobj"]["subarray"][1] -> 2
+	jq.Int("subobj.subarray[1]")
+
+	// data["subobj"]["subarray"]["array"][0] -> "hello"
+	jq.String("subobj.subsubobj.array[0]")
+	```
+
+Finally, As functions have been included so that if you are *sure* the call will succeed you can inline the values. If these calls encounter an error they will panic:
+
+	```go
+	// data["subobj"]["subarray"][1] -> 2
+	fmt.Printf("%d\n", jq.AsInt("subobj", "subarray", "1"))
+	fmt.Printf("%d\n", jq.AsInt("subobj.subarray[1]"))
+
+	// data["subobj"]["subarray"]["array"][0] -> "hello"
+	fmt.Printf("%s\n", jq.AsString("subobj", "subsubobj", "array", "0"))
+	fmt.Printf("%s\n", jq.AsString("subobj.subsubobj.array[0]"))
+	```
+
+
 	Notes:
 
 Missing keys, out of bounds indexes, and type failures will return errors.

--- a/jsonq.go
+++ b/jsonq.go
@@ -9,7 +9,8 @@ import (
 // JsonQuery is an object that enables querying of a Go map with a simple
 // positional query language.
 type JsonQuery struct {
-	blob map[string]interface{}
+	blob                    map[string]interface{}
+	SingleValuePanicOnError bool
 }
 
 // stringFromInterface converts an interface{} to a string and returns an error if types don't match.
@@ -84,6 +85,7 @@ func arrayFromInterface(val interface{}) ([]interface{}, error) {
 func NewQuery(data interface{}) *JsonQuery {
 	j := new(JsonQuery)
 	j.blob = data.(map[string]interface{})
+	j.SingleValuePanicOnError = true
 	return j
 }
 
@@ -100,7 +102,10 @@ func (j *JsonQuery) Bool(s ...string) (bool, error) {
 func (j *JsonQuery) AsBool(s ...string) bool {
 	val, err := j.Bool(s...)
 	if err != nil {
-		panic(err)
+		if j.SingleValuePanicOnError {
+			panic(err)
+		}
+		return false
 	}
 	return val
 }
@@ -118,7 +123,10 @@ func (j *JsonQuery) Float(s ...string) (float64, error) {
 func (j *JsonQuery) AsFloat(s ...string) float64 {
 	val, err := j.Float(s...)
 	if err != nil {
-		panic(err)
+		if j.SingleValuePanicOnError {
+			panic(err)
+		}
+		return 0.0
 	}
 	return val
 }
@@ -136,7 +144,9 @@ func (j *JsonQuery) Int(s ...string) (int, error) {
 func (j *JsonQuery) AsInt(s ...string) int {
 	val, err := j.Int(s...)
 	if err != nil {
-		panic(err)
+		if j.SingleValuePanicOnError {
+			panic(err)
+		}
 	}
 	return val
 }
@@ -154,9 +164,20 @@ func (j *JsonQuery) String(s ...string) (string, error) {
 func (j *JsonQuery) AsString(s ...string) string {
 	val, err := j.String(s...)
 	if err != nil {
-		panic(err)
+		if j.SingleValuePanicOnError {
+			panic(err)
+		}
 	}
 	return val
+}
+
+// Exists return true if node can be accessed, else false
+func (j *JsonQuery) Exists(s ...string) bool {
+	_, err := j.Interface(s...)
+	if err != nil {
+		return false
+	}
+	return true
 }
 
 // Object extracts a json object from the JsonQuery
@@ -172,7 +193,9 @@ func (j *JsonQuery) Object(s ...string) (map[string]interface{}, error) {
 func (j *JsonQuery) AsObject(s ...string) map[string]interface{} {
 	val, err := j.Object(s...)
 	if err != nil {
-		panic(err)
+		if j.SingleValuePanicOnError {
+			panic(err)
+		}
 	}
 	return val
 }
@@ -190,7 +213,9 @@ func (j *JsonQuery) Array(s ...string) ([]interface{}, error) {
 func (j *JsonQuery) AsArray(s ...string) []interface{} {
 	val, err := j.Array(s...)
 	if err != nil {
-		panic(err)
+		if j.SingleValuePanicOnError {
+			panic(err)
+		}
 	}
 	return val
 }
@@ -208,7 +233,9 @@ func (j *JsonQuery) Interface(s ...string) (interface{}, error) {
 func (j *JsonQuery) AsInterface(s ...string) interface{} {
 	val, err := j.Interface(s...)
 	if err != nil {
-		panic(err)
+		if j.SingleValuePanicOnError {
+			panic(err)
+		}
 	}
 	return val
 }
@@ -233,7 +260,9 @@ func (j *JsonQuery) ArrayOfStrings(s ...string) ([]string, error) {
 func (j *JsonQuery) AsArrayOfStrings(s ...string) []string {
 	val, err := j.ArrayOfStrings(s...)
 	if err != nil {
-		panic(err)
+		if j.SingleValuePanicOnError {
+			panic(err)
+		}
 	}
 	return val
 }
@@ -258,7 +287,9 @@ func (j *JsonQuery) ArrayOfInts(s ...string) ([]int, error) {
 func (j *JsonQuery) AsArrayOfInts(s ...string) []int {
 	val, err := j.ArrayOfInts(s...)
 	if err != nil {
-		panic(err)
+		if j.SingleValuePanicOnError {
+			panic(err)
+		}
 	}
 	return val
 }
@@ -283,7 +314,9 @@ func (j *JsonQuery) ArrayOfFloats(s ...string) ([]float64, error) {
 func (j *JsonQuery) AsArrayOfFloats(s ...string) []float64 {
 	val, err := j.ArrayOfFloats(s...)
 	if err != nil {
-		panic(err)
+		if j.SingleValuePanicOnError {
+			panic(err)
+		}
 	}
 	return val
 }
@@ -308,7 +341,9 @@ func (j *JsonQuery) ArrayOfBools(s ...string) ([]bool, error) {
 func (j *JsonQuery) AsArrayOfBools(s ...string) []bool {
 	val, err := j.ArrayOfBools(s...)
 	if err != nil {
-		panic(err)
+		if j.SingleValuePanicOnError {
+			panic(err)
+		}
 	}
 	return val
 }
@@ -333,7 +368,9 @@ func (j *JsonQuery) ArrayOfObjects(s ...string) ([]map[string]interface{}, error
 func (j *JsonQuery) AsArrayOfObjects(s ...string) []map[string]interface{} {
 	val, err := j.ArrayOfObjects(s...)
 	if err != nil {
-		panic(err)
+		if j.SingleValuePanicOnError {
+			panic(err)
+		}
 	}
 	return val
 }
@@ -358,7 +395,9 @@ func (j *JsonQuery) ArrayOfArrays(s ...string) ([][]interface{}, error) {
 func (j *JsonQuery) AsArrayOfArrays(s ...string) [][]interface{} {
 	val, err := j.ArrayOfArrays(s...)
 	if err != nil {
-		panic(err)
+		if j.SingleValuePanicOnError {
+			panic(err)
+		}
 	}
 	return val
 }

--- a/jsonq.go
+++ b/jsonq.go
@@ -3,6 +3,7 @@ package jsonq
 import (
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 // JsonQuery is an object that enables querying of a Go map with a simple
@@ -95,6 +96,15 @@ func (j *JsonQuery) Bool(s ...string) (bool, error) {
 	return boolFromInterface(val)
 }
 
+// AsBool extracts a bool the JsonQuery, but panics on error so it can be used inline
+func (j *JsonQuery) AsBool(s ...string) bool {
+	val, err := j.Bool(s...)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // Float extracts a float from the JsonQuery
 func (j *JsonQuery) Float(s ...string) (float64, error) {
 	val, err := rquery(j.blob, s...)
@@ -102,6 +112,15 @@ func (j *JsonQuery) Float(s ...string) (float64, error) {
 		return 0.0, err
 	}
 	return floatFromInterface(val)
+}
+
+// AsFloat extracts a float from the JsonQuery, but panics on error so it can be used inline
+func (j *JsonQuery) AsFloat(s ...string) float64 {
+	val, err := j.Float(s...)
+	if err != nil {
+		panic(err)
+	}
+	return val
 }
 
 // Int extracts an int from the JsonQuery
@@ -113,6 +132,15 @@ func (j *JsonQuery) Int(s ...string) (int, error) {
 	return intFromInterface(val)
 }
 
+// AsInt extracts an int from the JsonQuery, but panics on error so it can be used inline
+func (j *JsonQuery) AsInt(s ...string) int {
+	val, err := j.Int(s...)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // String extracts a string from the JsonQuery
 func (j *JsonQuery) String(s ...string) (string, error) {
 	val, err := rquery(j.blob, s...)
@@ -120,6 +148,15 @@ func (j *JsonQuery) String(s ...string) (string, error) {
 		return "", err
 	}
 	return stringFromInterface(val)
+}
+
+// AsString extracts a string from the JsonQuery, but panics on error so it can be used inline
+func (j *JsonQuery) AsString(s ...string) string {
+	val, err := j.String(s...)
+	if err != nil {
+		panic(err)
+	}
+	return val
 }
 
 // Object extracts a json object from the JsonQuery
@@ -131,6 +168,15 @@ func (j *JsonQuery) Object(s ...string) (map[string]interface{}, error) {
 	return objectFromInterface(val)
 }
 
+// AsObject extracts a json object from the JsonQuery, but panics on error so it can be used inline
+func (j *JsonQuery) AsObject(s ...string) map[string]interface{} {
+	val, err := j.Object(s...)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // Array extracts a []interface{} from the JsonQuery
 func (j *JsonQuery) Array(s ...string) ([]interface{}, error) {
 	val, err := rquery(j.blob, s...)
@@ -140,6 +186,15 @@ func (j *JsonQuery) Array(s ...string) ([]interface{}, error) {
 	return arrayFromInterface(val)
 }
 
+// AsArray extracts a []interface{} from the JsonQuery, but panics on error so it can be used inline
+func (j *JsonQuery) AsArray(s ...string) []interface{} {
+	val, err := j.Array(s...)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // Interface extracts an interface{} from the JsonQuery
 func (j *JsonQuery) Interface(s ...string) (interface{}, error) {
 	val, err := rquery(j.blob, s...)
@@ -147,6 +202,15 @@ func (j *JsonQuery) Interface(s ...string) (interface{}, error) {
 		return nil, err
 	}
 	return val, nil
+}
+
+// AsInterface extracts an interface{} from the JsonQuery, but panics on error so it can be used inline
+func (j *JsonQuery) AsInterface(s ...string) interface{} {
+	val, err := j.Interface(s...)
+	if err != nil {
+		panic(err)
+	}
+	return val
 }
 
 // ArrayOfStrings extracts an array of strings from some json
@@ -165,6 +229,15 @@ func (j *JsonQuery) ArrayOfStrings(s ...string) ([]string, error) {
 	return toReturn, nil
 }
 
+// AsArrayOfStrings extracts an array of strings from some json, but panics on error so it can be used inline
+func (j *JsonQuery) AsArrayOfStrings(s ...string) []string {
+	val, err := j.ArrayOfStrings(s...)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // ArrayOfInts extracts an array of ints from some json
 func (j *JsonQuery) ArrayOfInts(s ...string) ([]int, error) {
 	array, err := j.Array(s...)
@@ -179,6 +252,15 @@ func (j *JsonQuery) ArrayOfInts(s ...string) ([]int, error) {
 		}
 	}
 	return toReturn, nil
+}
+
+// AsArrayOfInts extracts an array of ints from some json, but panics on error so it can be used inline
+func (j *JsonQuery) AsArrayOfInts(s ...string) []int {
+	val, err := j.ArrayOfInts(s...)
+	if err != nil {
+		panic(err)
+	}
+	return val
 }
 
 // ArrayOfFloats extracts an array of float64s from some json
@@ -197,6 +279,15 @@ func (j *JsonQuery) ArrayOfFloats(s ...string) ([]float64, error) {
 	return toReturn, nil
 }
 
+// AsArrayOfFloats extracts an array of float64s from some json, but panics on error so it can be used inline
+func (j *JsonQuery) AsArrayOfFloats(s ...string) []float64 {
+	val, err := j.ArrayOfFloats(s...)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // ArrayOfBools extracts an array of bools from some json
 func (j *JsonQuery) ArrayOfBools(s ...string) ([]bool, error) {
 	array, err := j.Array(s...)
@@ -211,6 +302,15 @@ func (j *JsonQuery) ArrayOfBools(s ...string) ([]bool, error) {
 		}
 	}
 	return toReturn, nil
+}
+
+// AsArrayOfBools extracts an array of bools from some json, but panics on error so it can be used inline
+func (j *JsonQuery) AsArrayOfBools(s ...string) []bool {
+	val, err := j.ArrayOfBools(s...)
+	if err != nil {
+		panic(err)
+	}
+	return val
 }
 
 // ArrayOfObjects extracts an array of map[string]interface{} (objects) from some json
@@ -229,6 +329,15 @@ func (j *JsonQuery) ArrayOfObjects(s ...string) ([]map[string]interface{}, error
 	return toReturn, nil
 }
 
+// AsArrayOfObjects extracts an array of map[string]interface{} (objects) from some json, but panics on error so it can be used inline
+func (j *JsonQuery) AsArrayOfObjects(s ...string) []map[string]interface{} {
+	val, err := j.ArrayOfObjects(s...)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // ArrayOfArrays extracts an array of []interface{} (arrays) from some json
 func (j *JsonQuery) ArrayOfArrays(s ...string) ([][]interface{}, error) {
 	array, err := j.Array(s...)
@@ -245,9 +354,23 @@ func (j *JsonQuery) ArrayOfArrays(s ...string) ([][]interface{}, error) {
 	return toReturn, nil
 }
 
+// AsArrayOfArrays extracts an array of []interface{} (arrays) from some json, but panics on error so it can be used inline
+func (j *JsonQuery) AsArrayOfArrays(s ...string) [][]interface{} {
+	val, err := j.ArrayOfArrays(s...)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // Matrix2D is an alias for ArrayOfArrays
 func (j *JsonQuery) Matrix2D(s ...string) ([][]interface{}, error) {
 	return j.ArrayOfArrays(s...)
+}
+
+// AsMatrix2D is an alias for ArrayOfArrays
+func (j *JsonQuery) AsMatrix2D(s ...string) [][]interface{} {
+	return j.AsArrayOfArrays(s...)
 }
 
 // Recursively query a decoded json blob
@@ -256,8 +379,17 @@ func rquery(blob interface{}, s ...string) (interface{}, error) {
 		val interface{}
 		err error
 	)
+
+	// If there is only a single string argument and if that single string argument has either a "." or a "[" in it
+	// the assume it is a path specification and disagregate it into an array of indexes.
+	terms := s
+	if len(s) == 1 && strings.IndexAny(s[0], ".[]") != -1 {
+		terms = strings.FieldsFunc(s[0], func(c rune) bool {
+			return c == '.' || c == '[' || c == ']'
+		})
+	}
 	val = blob
-	for _, q := range s {
+	for _, q := range terms {
 		val, err = query(val, q)
 		if err != nil {
 			return nil, err

--- a/jsonq_test.go
+++ b/jsonq_test.go
@@ -59,17 +59,43 @@ func TestQuery(t *testing.T) {
 		t.Errorf("Expecting 1, got %v\n", ival)
 	}
 	tErr(t, err)
+
+	ival = q.AsInt("foo")
+	if ival != 1 {
+		t.Errorf("Expecting 1, got %v\n", ival)
+	}
+
 	ival, err = q.Int("bar")
 	if ival != 2 {
 		t.Errorf("Expecting 2, got %v\n", ival)
 	}
 	tErr(t, err)
+	ival = q.AsInt("bar")
+	if ival != 2 {
+		t.Errorf("Expecting 2, got %v\n", ival)
+	}
 
 	ival, err = q.Int("subobj", "foo")
 	if ival != 1 {
 		t.Errorf("Expecting 1, got %v\n", ival)
 	}
 	tErr(t, err)
+
+	ival, err = q.Int("subobj.foo")
+	if ival != 1 {
+		t.Errorf("Expecting 1, got %v\n", ival)
+	}
+	tErr(t, err)
+
+	ival = q.AsInt("subobj", "foo")
+	if ival != 1 {
+		t.Errorf("Expecting 1, got %v\n", ival)
+	}
+
+	ival = q.AsInt("subobj.foo")
+	if ival != 1 {
+		t.Errorf("Expecting 1, got %v\n", ival)
+	}
 
 	// test that strings can get int-ed
 	ival, err = q.Int("numstring")
@@ -109,6 +135,17 @@ func TestQuery(t *testing.T) {
 		t.Errorf("Expecting \"hello\", got \"%s\"\n", sval)
 	}
 	tErr(t, err)
+
+	sval, err = q.String("subobj.subsubobj.array[0]")
+	if sval != "hello" {
+		t.Errorf("Expecting \"hello\", got \"%s\"\n", sval)
+	}
+	tErr(t, err)
+
+	sval = q.AsString("subobj.subsubobj.array[0]")
+	if sval != "hello" {
+		t.Errorf("Expecting \"hello\", got \"%s\"\n", sval)
+	}
 
 	bval, err := q.Bool("bool")
 	if !bval {


### PR DESCRIPTION
First, thanks for the library, very helpful. I added a couple of things 
- path functions so you can perform a query as a path as opposed to multiple arguments. Just provides a single string syntax really. Splits the string and processes normally.

``` go
sval, err := jq.String("subobj.subsubobj.array[3]")
```
- single value return methods so they can be used in line without error checking. these funcs panic on error

``` go
sval := jq.AsString("subobj", "subsubobj", "array", "3")
sval := jq.AsString("subobj.subsubobj.array[3]")
```

Let me know what you think and merge if you approve please.
